### PR TITLE
feat: selecionando elementos

### DIFF
--- a/cypress/e2e/login.cy.js
+++ b/cypress/e2e/login.cy.js
@@ -1,9 +1,19 @@
 // Descrição de qual funcionalidade a ser testada
 describe('Login', () => {
-
     // Cenários de testes
     it('Login com sucesso', () => {
-        cy.visit('/')
-    })
+        // get() -> seleciona elementos
+        cy.visit('/').get('.header-logo');
 
-})
+        // contains() -> encontra elementos por texto. Geralmente diminuímos o escopo com um get().
+        cy.get('#top_header').contains('Login');
+
+        // find() -> encontra elementos. Geralmente diminuímos o escopo com um get().
+        cy.get('#top_header').find('.fa-user');
+
+        // as() - alias -> cria apelidos (atalhos) para grandes comandos
+        // Para referenciar um alias em outros lugares do teste, usa-se o método 'cy.get()' com o alias precedido por um '@'.
+        cy.get('#top_header').as('cabecalho');
+        cy.get('@cabecalho').find('.fa-user');
+    });
+});


### PR DESCRIPTION
**O que foi aprendido?**

Selecionar elementos usando os métodos:
- `get()`: seleciona elementos baseado no seletor CSS;
- `constains()`: encontra elementos por texto. Geralmente, usa-se o método `get()` para diminuir o escopo antes de usar `contains()`;
- `find()`: encontra elementos dentro de um elemento já selecionado. Novamente, geralmente diminui o escopo com um `get()` antes de usar `find()`;
- `as()`: cria apelidos (atalhos) para grandes comandos. Para referenciar um alias em outros lugares do teste, usa-se o método 'cy.get()' com o alias precedido por um '@'.

