### PR TITLE
feat: digitando e clicando em um elemento

### DIFF
--- a/cypress/e2e/interacoes.cy.js
+++ b/cypress/e2e/interacoes.cy.js
@@ -1,0 +1,30 @@
+/// <reference types="cypress" />
+
+// Descrição de qual funcionalidade a ser testada
+describe('Interações', () => {
+    // Cenários de testes
+    // it('Digitar em um campo', () => {
+    //     cy.visit('/').get('.header-logo');
+
+        // cy.get('.form-control').type('sakura@email.com');
+    // });
+
+    it('Click', () => {
+        cy.visit('/').get('.header-logo');
+
+        // Simular apertar "enter"
+        cy.get('.form-control').type('sakura@email.com{enter}');
+
+        // Click normal
+        // cy.get('.fa-user').click()
+
+        // Click duplo
+        // cy.get('.fa-user').dblclick()
+
+        // Click botão direito do mouse
+        // cy.get('.fa-user').rightclick()
+
+        // Click por cordenadas
+        // cy.get('.fa-user').click(100,100, {force: true})
+    })
+});


### PR DESCRIPTION
**O que foi aprendido?**

Referenciar o Cypress:

- A linha `/// <reference types="cypress" />` é uma diretiva de comentário especial que indica ao editor de código para incluir os tipos Cypress.

Digitar em um elemento (`input`):

- `type():` usado para simular a digitação do texto fornecido no elemento de entrada.

Clicar em um elemento:

- `click()`: usado para simular um clique do mouse;
- `dblclick()`: usado para simular um clique duplo do mouse;
- `rightclick()`: usado para simular um clique com o botão direito do mouse;
- `type('sakura@email.com{enter}')`: usado para simular a digitação seguida de pressionar a tecla "Enter".
