### PR TITLE
feat: asserts

### DIFF
--- a/cypress/e2e/asserts.cy.js
+++ b/cypress/e2e/asserts.cy.js
@@ -1,0 +1,26 @@
+/// <reference types="cypress" />
+
+// Asserts: verifica se uma determinada condição é verdadeira
+describe('Asserts', () => {
+    
+    it('Verificar se está visível', () => {
+        cy.visit('/').get('.header-logo');
+
+        cy.get('.fa-user').should('be.visible').click();
+
+        // Validar usando should
+        // should(): afirma que algo deve ser verdadeiro durante a execução do teste
+        cy.get('.account_form > h3').should('be.visible');
+
+        cy.get('.account_form > h3').should('contain', 'Login').should('have.text', 'Login');
+
+        // Outra maneira de validar é usando expect para asserts
+        // Muito usado em teste de APIs
+        cy.get('.account_form > h3').then((element) => {
+            expect(element.text()).eq('Login');
+            expect(element).to.be.visible;
+            expect(element).not.disabled;
+        })
+    });  
+
+});


### PR DESCRIPTION
**O que foi aprendido?**

Introdução a asserts (should):

- **Asserts**: verificam se uma determinada condição é verdadeira. Se a condição for falsa, o programa normalmente para de executar e gera uma mensagem de erro. Em testes automatizados, usa-se “asserts” para verificar se o comportamento do código está correto;
- `.should()`: usado para fazer afirmações sobre o estado do aplicativo. Ele é usado para afirmar que algo deve ser verdadeiro durante a execução do teste. Por exemplo, `.should('be.visible')` verifica se o elemento selecionado está visível na página, e `.should('contain', 'texto')` verifica se o elemento selecionado contém um determinado texto  e `.should('have.text', 'texto')` verifica se o texto do elemento selecionado é exatamente igual ao texto fornecido.

Usando expect para asserts:

- `expect()`: outra maneira de fazer afirmações e é muito usado em testes de APIs por várias razões:

    **1. Flexibilidade:** ampla variedade de afirmações sobre a resposta da API, incluindo o status da resposta, os cabeçalhos da resposta e o corpo da resposta;
    **2. Legibilidade:** expect() usa uma sintaxe encadeada que é fácil de ler e escrever. Isso torna os testes mais compreensíveis, o que é especialmente útil quando você está trabalhando em uma equipe e precisa que outros possam entender seus testes;
    **3. Assertivas detalhadas:** é possível fazer assertivas muito específicas sobre a resposta da API. Por exemplo, verificar se um campo específico é igual a um valor específico;
    **4. Integração com bibliotecas de assertivas:** pode ser usado com bibliotecas de assertivas como Chai, que fornecem ainda mais opções de assertivas e melhoram a legibilidade dos testes.