### PR TITLE
feat: usando as fixtures

### DIFF
--- a/cypress/e2e/desafio.cy.js
+++ b/cypress/e2e/desafio.cy.js
@@ -1,12 +1,10 @@
 /// <reference types="cypress" />
 
-describe('Cadastro de usuário', () => {
-    const user_name = 'Testando';
-    const user_email_invalid = 'E-mail inválido';
-    const user_email = 'email-valido@email.com';
-    const user_password_invalid = '123';
-    const user_password = '123456';
+// Usa-se a pasta 'fixtures' para armazenar dados que são usados durante os testes
+const user_data = require('../fixtures/desafio_valid_data.json');
+const user_invalid_data = require('../fixtures/desafio_invalid_data.json');
 
+describe('Cadastro de usuário', () => {
     it('Validar campo nome vazio', () => {
         cy.visit('/').get('.header-logo');
 
@@ -22,7 +20,7 @@ describe('Cadastro de usuário', () => {
 
         cy.get('.fa-lock').should('be.visible').click();
 
-        cy.get('#user').should('be.visible').type(user_name);
+        cy.get('#user').should('be.visible').type(user_data.name);
 
         cy.get('#btnRegister').should('be.visible').click();
 
@@ -37,9 +35,9 @@ describe('Cadastro de usuário', () => {
 
         cy.get('.fa-lock').should('be.visible').click();
 
-        cy.get('#user').should('be.visible').type(user_name);
+        cy.get('#user').should('be.visible').type(user_data.name);
 
-        cy.get('#email').should('be.visible').type(user_email_invalid);
+        cy.get('#email').should('be.visible').type(user_invalid_data.email);
 
         cy.get('#btnRegister').should('be.visible').click();
 
@@ -54,9 +52,9 @@ describe('Cadastro de usuário', () => {
 
         cy.get('.fa-lock').should('be.visible').click();
 
-        cy.get('#user').should('be.visible').type(user_name);
+        cy.get('#user').should('be.visible').type(user_data.name);
 
-        cy.get('#email').should('be.visible').type(user_email);
+        cy.get('#email').should('be.visible').type(user_data.email);
 
         cy.get('#btnRegister').should('be.visible').click();
 
@@ -71,11 +69,11 @@ describe('Cadastro de usuário', () => {
 
         cy.get('.fa-lock').should('be.visible').click();
 
-        cy.get('#user').should('be.visible').type(user_name);
+        cy.get('#user').should('be.visible').type(user_data.name);
 
-        cy.get('#email').should('be.visible').type(user_email);
+        cy.get('#email').should('be.visible').type(user_data.email);
 
-        cy.get('#password').should('be.visible').type(user_password_invalid);
+        cy.get('#password').should('be.visible').type(user_invalid_data.password);
 
         cy.get('#btnRegister').should('be.visible').click();
 
@@ -90,17 +88,17 @@ describe('Cadastro de usuário', () => {
 
         cy.get('.fa-lock').should('be.visible').click();
 
-        cy.get('#user').should('be.visible').type(user_name);
+        cy.get('#user').should('be.visible').type(user_data.name);
 
-        cy.get('#email').should('be.visible').type(user_email);
+        cy.get('#email').should('be.visible').type(user_data.email);
 
-        cy.get('#password').should('be.visible').type(user_password);
+        cy.get('#password').should('be.visible').type(user_data.password);
 
         cy.get('#btnRegister').should('be.visible').click();
 
         cy.get('#swal2-title').should('contain', 'Cadastro realizado!');
 
-        cy.get('#swal2-html-container').should('contain', `Bem-vindo ${user_name}`);
+        cy.get('#swal2-html-container').should('contain', `Bem-vindo ${user_data.name}`);
 
         cy.get('button.swal2-confirm.swal2-styled').click();
     });

--- a/cypress/fixtures/desafio_invalid_data.json
+++ b/cypress/fixtures/desafio_invalid_data.json
@@ -1,0 +1,4 @@
+{
+    "email": "E-mail inválido",
+    "password": "123"
+}

--- a/cypress/fixtures/desafio_valid_data.json
+++ b/cypress/fixtures/desafio_valid_data.json
@@ -1,0 +1,5 @@
+{
+    "name": "Testando",
+    "email": "email-valido@email.com",
+    "password": "123456"
+}


### PR DESCRIPTION
**O que foi aprendido?**

Usando fixtures no Cypress:

- **Separação de dados e scripts de teste:** armazenar os dados de teste na pasta ‘fixtures’ permite separar os dados de teste dos scripts de teste, tornando os scripts de teste mais limpos e mais fáceis de manter;
- **Reutilização de dados de teste:** os dados na pasta ‘fixtures’ podem ser reutilizados em vários testes. Isso evita a duplicação de dados e torna mais fácil atualizar os dados de teste;
- **Simulação de comportamentos:** usar a pasta ‘fixtures’ para armazenar dados que simulam diferentes comportamentos do sistema. Por exemplo, pode-se ter arquivos de fixture que representam respostas de API válidas e inválidas;
- **Testes mais previsíveis:** como os dados na pasta ‘fixtures’ são fixos, eles ajudam a tornar os testes mais previsíveis, sabendo exatamente quais dados estão sendo usados nos testes, o que pode ajudar a evitar falhas de teste causadas por dados inesperados.