### PR TITLE
feat: page objects comandos personalizados

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -3,6 +3,7 @@ const { defineConfig } = require("cypress");
 module.exports = defineConfig({
   e2e: {
     baseUrl: 'https://www.automationpratice.com.br/',
+    defaultCommandTimeout: 5000, // Timeout padrão do projeto todo
     setupNodeEvents(on, config) {
       // implement node event listeners here
     },

--- a/cypress/e2e/desafio_po_cypress.cy.js
+++ b/cypress/e2e/desafio_po_cypress.cy.js
@@ -1,0 +1,59 @@
+// -- Aula sobre Page Objects com comandos personalizados do Cypress --
+
+/// <reference types="cypress" />
+// Utilizando a biblioteca Faker para gerar massa de dados
+import { faker } from '@faker-js/faker';
+
+const user_data = require('../fixtures/desafio_valid_data.json');
+const user_invalid_data = require('../fixtures/desafio_invalid_data.json');
+
+const random_name = faker.person.fullName();
+const random_email = faker.internet.email();
+
+describe('Cadastro de usuário', () => {
+    beforeEach('Acessando página de cadastro', () => {
+        cy.accessRegisterPage();
+    });
+
+    it('Validar campo nome vazio', () => {
+        cy.saveRegister();
+        cy.checkMessage('O campo nome deve ser prenchido');
+    });
+
+    it('Validar campo e-mail vazio', () => {
+        cy.fillName(random_name);
+        cy.saveRegister();
+        cy.checkMessage('O campo e-mail deve ser prenchido corretamente');
+    });
+
+    it('Validar campo e-mail inválido', () => {
+        cy.fillName(random_name);
+        cy.fillEmail(user_invalid_data.email);
+        cy.saveRegister();
+        cy.checkMessage('O campo e-mail deve ser prenchido corretamente');
+    });
+
+    it('Validar campo senha vazio', () => {
+        cy.fillName(random_name);
+        cy.fillEmail(random_email);
+        cy.saveRegister();
+        cy.checkMessage('O campo senha deve ter pelo menos 6 dígitos');
+    });
+
+    it('Validar campo senha inválido', () => {
+        cy.fillName(random_name);
+        cy.fillEmail(random_email);
+        cy.fillPassword(user_invalid_data.password);
+        cy.saveRegister();
+        cy.checkMessage('O campo senha deve ter pelo menos 6 dígitos');
+    });
+
+    it('Validar cadastro de usuário com sucesso', () => {
+        cy.fillName(random_name);
+        cy.fillEmail(random_email);
+        cy.fillPassword(user_data.password);
+        cy.saveRegister();
+        cy.checkRegisterSucess('Cadastro realizado!', random_name);
+        cy.confirmRegistration();
+    });
+});

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -15,6 +15,8 @@
 
 // Import commands.js using ES2015 syntax:
 import './commands'
+import './home_page_commands'
+import './register_page_commands'
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/cypress/support/home_page_commands.js
+++ b/cypress/support/home_page_commands.js
@@ -1,0 +1,16 @@
+// -- Cria novos comandos no projeto  --
+// Cypress.Commands.add('login', (email, password) => { ... })
+//
+// -- Sobrescreve um comando que existente --
+// Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
+
+/// <reference types="cypress" />
+
+Cypress.Commands.add('accessRegisterPage', () => {
+    // Acessa a aplicação
+    cy.visit('/').get('.header-logo');
+    // Entra no registro
+    cy.get('.fa-lock').should('be.visible').click();
+    // Verifica se está na página de cadastro
+    cy.get('#user').should('be.visible');
+})

--- a/cypress/support/register_page_commands.js
+++ b/cypress/support/register_page_commands.js
@@ -1,0 +1,37 @@
+/// <reference types="cypress" />
+
+Cypress.Commands.add('saveRegister', () => {
+    // Clica no registrar
+    cy.get('#btnRegister').click();
+});
+
+Cypress.Commands.add('fillEmail', (email) => {
+    // Preenche email
+    cy.get('#email').should('be.visible').type(email);
+});
+
+Cypress.Commands.add('fillName', (name) => {
+    // Preenche nome
+    cy.get('#user').type(name);
+});
+
+Cypress.Commands.add('fillPassword', (password) => {
+    // Preenche senha
+    cy.get('#password').should('be.visible').type(password);
+});
+
+Cypress.Commands.add('checkMessage', (message) => {
+    // Checar mensagem
+    cy.get('#errorMessageFirstName').should('contain', message);
+});
+
+Cypress.Commands.add('checkRegisterSucess', (message, name) => {
+    // Cadastro concluído
+    cy.get('#swal2-title').should('contain', message);
+    cy.get('#swal2-html-container').should('contain', `Bem-vindo ${name}`);
+});
+
+Cypress.Commands.add('confirmRegistration', () => {
+    // Clica para confirmar o registro
+    cy.get('button.swal2-confirm.swal2-styled').click();
+});


### PR DESCRIPTION
**O que foi aprendido?**

Page Objects com comandos personalizados do Cypress:

- Os comandos personalizados do Cypress são uma maneira de adicionar novos comandos ou sobrescrever os comandos existentes. Eles são úteis para encapsular a lógica de teste que é usada com frequência em um único comando reutilizável;
- No código, há uma pasta chamada `support` que contém um arquivo chamado `e2e.js`. Este arquivo é responsável pelas importações dos comandos;
- O arquivo `e2e.js` importa outro arquivo chamado `commands.js`. Inicialmente, o `commands.js` pode estar vazio, mas é aqui que os comandos personalizados são adicionados;
- Quando o arquivo `e2e.js` importa outro arquivo, ele torna todos os arquivos importados visíveis para todo o projeto. Isso significa que qualquer comando personalizado que for adicionado ao `commands.js` estará disponível em todo o projeto de teste;
- Configuração padrão do timeout, `defaultCommandTimeout: 5000`, que é o tempo limite padrão para todos os comandos no projeto. Esta configuração é definida no arquivo` cypress.config.js.`: