### PR TITLE
feat: page objects com javascript

### DIFF
--- a/cypress/e2e/desafio_po_javascript.cy.js
+++ b/cypress/e2e/desafio_po_javascript.cy.js
@@ -1,0 +1,61 @@
+// -- Aula sobre Page Objects com comandos personalizados do Cypress --
+
+/// <reference types="cypress" />
+// Utilizando a biblioteca Faker para gerar massa de dados
+import { faker } from '@faker-js/faker';
+import home_page from '../support/pages/home_page';
+import register_page from '../support/pages/register_page';
+
+const user_data = require('../fixtures/desafio_valid_data.json');
+const user_invalid_data = require('../fixtures/desafio_invalid_data.json');
+
+const random_name = faker.person.fullName();
+const random_email = faker.internet.email();
+
+describe('Cadastro de usuário', () => {
+    beforeEach('Acessando página de cadastro', () => {
+        home_page.accessRegisterPage();
+    });
+
+    it('Validar campo nome vazio', () => {
+        register_page.saveRegister();
+        register_page.checkMessage('O campo nome deve ser prenchido');
+    });
+
+    it('Validar campo e-mail vazio', () => {
+        register_page.fillName(random_name);
+        register_page.saveRegister();
+        register_page.checkMessage('O campo e-mail deve ser prenchido corretamente');
+    });
+
+    it('Validar campo e-mail inválido', () => {
+        register_page.fillName(random_name);
+        register_page.fillEmail(user_invalid_data.email);
+        register_page.saveRegister();
+        register_page.checkMessage('O campo e-mail deve ser prenchido corretamente');
+    });
+
+    it('Validar campo senha vazio', () => {
+        register_page.fillName(random_name);
+        register_page.fillEmail(random_email);
+        register_page.saveRegister();
+        register_page.checkMessage('O campo senha deve ter pelo menos 6 dígitos');
+    });
+
+    it('Validar campo senha inválido', () => {
+        register_page.fillName(random_name);
+        register_page.fillEmail(random_email);
+        register_page.fillPassword(user_invalid_data.password);
+        register_page.saveRegister();
+        register_page.checkMessage('O campo senha deve ter pelo menos 6 dígitos');
+    });
+
+    it('Validar cadastro de usuário com sucesso', () => {
+        register_page.fillName(random_name);
+        register_page.fillEmail(random_email);
+        register_page.fillPassword(user_data.password);
+        register_page.saveRegister();
+        register_page.checkRegisterSucess('Cadastro realizado!', random_name);
+        register_page.confirmRegister();
+    });
+});

--- a/cypress/support/pages/home_page.js
+++ b/cypress/support/pages/home_page.js
@@ -19,11 +19,14 @@ const elements = {
     },
 };
 
-Cypress.Commands.add('accessRegisterPage', () => {
-    // Acessa a aplicação
-    cy.visit(elements.url.visit).get('.header-logo');
-    // Entra no registro
-    cy.get(elements.links.register).should('be.visible').click();
-    // Verifica se está na página de cadastro
-    cy.get(elements.fields.name).should('be.visible');
-})
+// Método JavaScript
+export default {
+    accessRegisterPage() {
+        // Acessa a aplicação
+        cy.visit(elements.url.visit).get('.header-logo');
+        // Entra no registro
+        cy.get(elements.links.register).should('be.visible').click();
+        // Verifica se está na página de cadastro
+        cy.get(elements.fields.name).should('be.visible');
+    },
+};

--- a/cypress/support/pages/register_page.js
+++ b/cypress/support/pages/register_page.js
@@ -1,0 +1,58 @@
+/// <reference types="cypress" />
+
+// Elementos
+const elements = {
+    buttons: {
+        register: '#btnRegister',
+        confirmRegister: 'button.swal2-confirm.swal2-styled',
+    },
+    fields: {
+        name: '#user',
+        email: '#email',
+        password: '#password',
+    },
+    messages: {
+        error: '#errorMessageFirstName',
+        successTitle: '#swal2-title',
+        successSubtitle: '#swal2-html-container',
+    },
+};
+
+// Ações/métodos/funções
+export default {
+    saveRegister() {
+        // Clica no registrar
+        cy.get(elements.buttons.register).click();
+    },
+
+    fillEmail(email) {
+        // Preenche email
+        cy.get(elements.fields.email).should('be.visible').type(email);
+    },
+
+    fillName(name) {
+        // Preenche nome
+        cy.get(elements.fields.name).type(name);
+    },
+
+    fillPassword(password) {
+        // Preenche senha
+        cy.get(elements.fields.password).should('be.visible').type(password);
+    },
+
+    checkMessage(message) {
+        // Checar mensagem
+        cy.get(elements.messages.error).should('contain', message);
+    },
+
+    checkRegisterSucess(message, name) {
+        // Cadastro concluído
+        cy.get(elements.messages.successTitle).should('contain', message);
+        cy.get(elements.messages.successSubtitle).should('contain', `Bem-vindo ${name}`);
+    },
+
+    confirmRegister() {
+        // Clica para confirmar o registro
+        cy.get(elements.buttons.confirmRegister).click();
+    },
+};


### PR DESCRIPTION
**O que foi aprendido?**

- **Page Objects com JavaScript:** com métodos JavaScript no Page Object, é possível associar ações específicas a páginas específicas, como no exemplo `home_page.accessRegisterPage()`. Comparando com os comandos do Cypress, onde se utiliza `cy.accessRegisterPage()`, a associação direta à página pode não ser tão clara.