### PR TITLE
feat: simulando device

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -4,6 +4,8 @@ module.exports = defineConfig({
   e2e: {
     baseUrl: 'https://www.automationpratice.com.br/',
     defaultCommandTimeout: 5000, // Timeout padrão do projeto todo
+    viewportHeight: 335,
+    viewportWidth: 999,
     setupNodeEvents(on, config) {
       // implement node event listeners here
     },

--- a/cypress/e2e/desafio_po_javascript.cy.js
+++ b/cypress/e2e/desafio_po_javascript.cy.js
@@ -8,22 +8,22 @@ import register_page from '../support/pages/register_page';
 
 const user_data = require('../fixtures/desafio_valid_data.json');
 const user_invalid_data = require('../fixtures/desafio_invalid_data.json');
-const screens = require('../support/config/viewport_sizes.json');
+// const screens = require('../support/config/viewport_sizes.json');
 
 const random_name = faker.person.fullName();
 const random_email = faker.internet.email();
 
-screens.forEach((element) => {
+// screens.forEach((element) => {
     describe('Cadastro de usuário', () => {
         beforeEach('Acessando página de cadastro', () => {
-            if (element.screen != 'desktop') {
-                cy.viewport(element.screen); // Simulação em telas de celulares
-            }
+            // if (element.screen != 'desktop') {
+            //     cy.viewport(element.screen); // Simulação em telas de celulares
+            // }
 
             home_page.accessRegisterPage();
         });
 
-        it.only('Validar campo nome vazio', () => {
+        it('Validar campo nome vazio', () => {
             register_page.saveRegister();
             register_page.checkMessage('O campo nome deve ser prenchido');
         });
@@ -65,4 +65,4 @@ screens.forEach((element) => {
             register_page.confirmRegister();
         });
     });
-});
+// });


### PR DESCRIPTION
**O que foi aprendido?**

Além do comando `viewport`, pode-se definir o tamanho da área de visualização do navegador globalmente no arquivo de configuração do Cypress (`cypress.config.js`). Isso é feito configurando a propriedade `viewportWidth` e `viewportHeight` no objeto de configuração. Essa abordagem define um tamanho padrão de viewport para todos os testes.